### PR TITLE
Round 4 of UI Fixes.

### DIFF
--- a/MessageCenter/Assets/GroupChannelChattingViewController.xib
+++ b/MessageCenter/Assets/GroupChannelChattingViewController.xib
@@ -139,7 +139,7 @@
                 <constraint firstItem="mOk-Vz-mXb" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="jrb-XI-ccp"/>
                 <constraint firstAttribute="trailing" secondItem="Kgd-6s-sEz" secondAttribute="trailing" id="poM-97-6RZ"/>
                 <constraint firstItem="Kgd-6s-sEz" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="rcY-nS-x5K"/>
-                <constraint firstItem="mOk-Vz-mXb" firstAttribute="bottom" secondItem="8zt-xK-G6h" secondAttribute="bottom" id="sqE-EN-eNq"/>
+                <constraint firstItem="mOk-Vz-mXb" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="sqE-EN-eNq"/>
                 <constraint firstAttribute="trailing" secondItem="AAA-Vq-7hk" secondAttribute="trailing" id="vXg-FO-oE6"/>
                 <constraint firstItem="8zt-xK-G6h" firstAttribute="bottom" secondItem="QWO-03-UeJ" secondAttribute="bottom" id="vYC-7U-Kit"/>
             </constraints>

--- a/MessageCenter/Classes/Views/Chatting/GroupChannelChattingViewController.swift
+++ b/MessageCenter/Classes/Views/Chatting/GroupChannelChattingViewController.swift
@@ -516,7 +516,7 @@ class GroupChannelChattingViewController: UIViewController, SBDConnectionDelegat
         if sender.state == .ended {
             view.endEditing(true)
         }
-        sender.cancelsTouchesInView = false
+        //sender.cancelsTouchesInView = false
     }
     
     @objc private func sendMessage() {
@@ -592,7 +592,7 @@ class GroupChannelChattingViewController: UIViewController, SBDConnectionDelegat
                         return
                     }
                     
-                    let index = IndexPath(row: self.chattingView.messages.index(of: preSendMessage)!, section: 0)
+                    let index = IndexPath(row: self.chattingView.messages.index(of: preSendMessage)! + 1, section: 0)
                     self.chattingView.chattingTableView.beginUpdates()
                     self.chattingView.messages[self.chattingView.messages.index(of: preSendMessage)!] = userMessage!
                     
@@ -618,7 +618,7 @@ class GroupChannelChattingViewController: UIViewController, SBDConnectionDelegat
                 
                 UIView.setAnimationsEnabled(false)
                 
-                self.chattingView.chattingTableView.insertRows(at: [IndexPath(row: self.chattingView.messages.index(of: preSendMessage)!, section: 0)], with: UITableViewRowAnimation.none)
+                self.chattingView.chattingTableView.insertRows(at: [IndexPath(row: self.chattingView.messages.index(of: preSendMessage)! + 1, section: 0)], with: UITableViewRowAnimation.none)
                 UIView.setAnimationsEnabled(true)
                 self.chattingView.chattingTableView.endUpdates()
                 
@@ -662,7 +662,8 @@ class GroupChannelChattingViewController: UIViewController, SBDConnectionDelegat
                 alertController.view.tintColor = UIColor(red: 82.0/255.0, green: 67.0/255.0, blue: 62.0/255.0, alpha: 1.0)
             }
         }
-        self.vwActionSheet.isHidden = false
+        //self.vwActionSheet.isHidden = false
+        setVwActionSheet(hidden: false)
     }
     
     private func cameraAction() -> UIAlertAction {
@@ -670,7 +671,8 @@ class GroupChannelChattingViewController: UIViewController, SBDConnectionDelegat
             title: "ms_camera".localized,
             style: .default,
             handler: { action in
-                self.vwActionSheet.isHidden = true
+                //self.vwActionSheet.isHidden = true
+                self.setVwActionSheet(hidden: true)
                 self.launchCamera()
         })
         action.setValue(UIImage(named: "camera-icon.png", in: Bundle(for: MessageCenter.self), compatibleWith: nil), forKey: "image")
@@ -697,7 +699,8 @@ class GroupChannelChattingViewController: UIViewController, SBDConnectionDelegat
             title: "ms_photos".localized,
             style: .default,
             handler: { action in
-                self.vwActionSheet.isHidden = true
+                //self.vwActionSheet.isHidden = true
+                self.setVwActionSheet(hidden: true)
                 UIImagePickerController.checkPermissionStatus(sourceType: UIImagePickerControllerSourceType.photoLibrary, completionBlockSuccess: { (status) in
                     let imagePicker = UIImagePickerController()                    
                     imagePicker.sourceType = .photoLibrary
@@ -719,7 +722,8 @@ class GroupChannelChattingViewController: UIViewController, SBDConnectionDelegat
             title: "ms_location".localized,
             style: .default,
             handler: { action in
-                self.vwActionSheet.isHidden = true
+                //self.vwActionSheet.isHidden = true
+                self.setVwActionSheet(hidden: true)
                 let podBundle = Bundle.bundleForXib(GroupChannelChattingViewController.self)
                 let locationPickerVC = SelectLocationViewController(nibName: "SelectLocationView", bundle: podBundle)
                 locationPickerVC.delegate = self as SelectLocationDelegate
@@ -734,7 +738,8 @@ class GroupChannelChattingViewController: UIViewController, SBDConnectionDelegat
             title: "cancel".localized,
             style: .cancel,
             handler : {action in
-                self.vwActionSheet.isHidden = true
+                //self.vwActionSheet.isHidden = true
+                self.setVwActionSheet(hidden: true)
         })
     }
     
@@ -1404,6 +1409,15 @@ class GroupChannelChattingViewController: UIViewController, SBDConnectionDelegat
             self.photosViewController.dismiss(animated: true, completion: nil)
         }
     }
+
+    // Disclaimer: I have no idea what vw stands for, but for the sake of convention, I'm naming my method accordingly.
+    private func setVwActionSheet(hidden: Bool) {
+        DispatchQueue.main.async {
+            UIView.animate(withDuration: 0.5, animations: {
+                self.vwActionSheet.alpha = hidden ? 0.0 : 0.75
+            })
+        }
+    }
 }
 
 // MARK: - UIImagePickerController Methods
@@ -1523,10 +1537,11 @@ fileprivate extension GroupChannelChattingViewController {
         let keyboardInfo = notification.userInfo
         let keyboardFrameBegin = keyboardInfo?[UIKeyboardFrameEndUserInfoKey]
         let keyboardFrameBeginRect = (keyboardFrameBegin as! NSValue).cgRectValue
-        
+        let duration = keyboardInfo?[UIKeyboardAnimationDurationUserInfoKey] as! NSNumber
+        let curve = keyboardInfo?[UIKeyboardAnimationCurveUserInfoKey] as! UInt
         DispatchQueue.main.async {
             self.bottomMargin.constant = keyboardFrameBeginRect.size.height
-            UIView.animate(withDuration: 0.25, delay: 0.0, options: .curveLinear
+            UIView.animate(withDuration: duration.doubleValue, delay: 0.0, options: [UIViewAnimationOptions(rawValue: UInt(curve))]
                 , animations: {
                     self.view.layoutIfNeeded()
             }, completion: { (status) in
@@ -1538,10 +1553,11 @@ fileprivate extension GroupChannelChattingViewController {
     
     @objc private func keyboardWillHide(notification: Notification) {
         self.keyboardShown = false
-        
+        let duration = notification.userInfo?[UIKeyboardAnimationDurationUserInfoKey] as! NSNumber
+        let curve = notification.userInfo?[UIKeyboardAnimationCurveUserInfoKey] as! UInt
         DispatchQueue.main.async {
             self.bottomMargin.constant = 0
-            UIView.animate(withDuration: 0.25, delay: 0.0, options: .curveLinear
+            UIView.animate(withDuration: duration.doubleValue, delay: 0.0, options: [UIViewAnimationOptions(rawValue: UInt(curve))]
                 , animations: {
                     self.view.layoutIfNeeded()
             }, completion: { (status) in

--- a/MessageCenter/Classes/Views/Location/SelectLocationViewController.swift
+++ b/MessageCenter/Classes/Views/Location/SelectLocationViewController.swift
@@ -85,6 +85,10 @@ public class SelectLocationViewController: UIViewController {
             return
         }
         
+        if locationAuthorizationStatus == .notDetermined {
+            // Yet to be determined.
+            return
+        }
         let alert = UIAlertController(title: "send_location.title".localized, message: "send_location.location_disabled_notice.message".localized, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "ok".localized, style: .default, handler: nil))
         self.present(alert, animated: true, completion: nil)


### PR DESCRIPTION
- Smoothed the view animation on showing/ hiding keyboard.
- Fixed a bug where if you sent a message, it'll clone the previous message.
- Fixed a bug where if you tapped the conversation thread, the keyboard will start to hide each time you click send message.
- Fixed the black overlay (a.k.a vwActionSheet) when you attach file for iX devices.
- Added animation on hiding/ showing the black overlay (a.k.a vwActionSheet)