### PR TITLE
Fix disconnect

### DIFF
--- a/MessageCenter.podspec
+++ b/MessageCenter.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'MessageCenter'
-  s.version          = '0.1.46'
+  s.version          = '0.1.47'
   s.summary          = 'MessageCenter is chatting SDK'
 
 # This description is used to generate tags and improve search results.

--- a/MessageCenter/Classes/Client/SendBirdClient.swift
+++ b/MessageCenter/Classes/Client/SendBirdClient.swift
@@ -117,8 +117,29 @@ public class SendBirdClient: ClientProtocol {
     }
   
     public func disconnect(completion: @escaping () -> Void) {
+        if self.isConnected == false {
+            if let connectionRequest = lastConnectionRequest {
+                SBDMain.connect(withUserId: connectionRequest.userId, accessToken: connectionRequest.accessToken, completionHandler: { [unowned self] (user, error) in
+                    guard error == nil else {
+                        completion()
+                        return;
+                    }
+                    self.unregisterFromSendBird {
+                        completion()
+                    }
+                })
+            }
+        }
+        else {
+            self.unregisterFromSendBird {
+                completion()
+            }
+        }
+    }
+    
+    private func unregisterFromSendBird (completion: @escaping () -> Void) {
         lastConnectionRequest = nil
-        SBDMain.unregisterAllPushToken { (a, error) in
+        SBDMain.unregisterAllPushToken {  [unowned self] (a, error) in
             guard error == nil else {
                 print("Failed to Disconnect")
                 return


### PR DESCRIPTION
-- Fixed SendBird disconnect issue. it won't affect the function implementation. From the iOS app, connect to sendbird is not required now, the SDK will handle the connect to Sendbird itself. (for disconnect only). 

- From iOS app, only call MessageCenter.disconnect {}